### PR TITLE
chore(deps): pin digests for GitHub Actions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -46,7 +46,7 @@ jobs:
           publish_results: true
 
       - name: "Upload Artifact"
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.pre.node20
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the upload-artifact action used in workflows to enhance performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->